### PR TITLE
Fix allfoods

### DIFF
--- a/server/api/ingredients.js
+++ b/server/api/ingredients.js
@@ -36,19 +36,19 @@ router.get('/', async (req, res, next) => {
 
     if (shoppingLists.length > 0) {
       //Get all the ingredients associated with the user's shopping lists.
-      ingredients.concat(
+      ingredients = ingredients.concat(
         shoppingLists.reduce((prev, list) => {
           return prev.concat(list.ingredients);
-        })
+        }, [])
       );
     }
 
     if (recipes.length > 0) {
       //Get all the ingredients associated with the user's recipes.
-      ingredients.concat(
+      ingredients = ingredients.concat(
         recipes.reduce((prev, recipe) => {
           return prev.concat(recipe.ingredients);
-        })
+        }, [])
       );
     }
 


### PR DESCRIPTION
I found the issue with the allFoods page. There was a syntax error in the GET api/ingredients route, whereby the recipe and shopping list ingredients were not assigned to the ingredients array. This failure occurred because I did not test this branch on ingredients associated with shopping lists or recipes, only the initial pantry data.