### PR TITLE
Initial Render now does pantry 1 as opposed to pantry 3

### DIFF
--- a/client/components/PantrySingle.js
+++ b/client/components/PantrySingle.js
@@ -14,11 +14,11 @@ const PantrySingle = ({ match }) => {
   const { id } = useSelector((state) => state.auth);
   const  pantry  = useSelector((state) => state.pantry);
   const { ingredients } = pantry || [];
-  const currentPantry = pantry.id
+  const currentPantry = pantry.id || 1
 
 
   useEffect(() => {
-    dispatch(fetchSinglePantry(id));
+    dispatch(fetchSinglePantry(currentPantry));
   }, []);
 
   async function handleChange(itemId, userId, quantity){


### PR DESCRIPTION
Harrison spotted a bug where clicking on the Pantry Tab in the navbar brought Users to a pantry based on their userId versus pantryId. For example, if you were logged in as admin, with a userId of 3, and you clicked on the Pantry tab, the first Pantry it would bring you to is your third pantry, assuming you had one. I fixed this problem by changing the values passed through a Thunk from the userId to either the currentPantry id or a default value of one