### PR TITLE
Features/improvedrecs

### DIFF
--- a/client/components/RecRecipes.js
+++ b/client/components/RecRecipes.js
@@ -37,7 +37,6 @@ const RecRecipes = () => {
       // let apiRequest =
       //   'https://api.edamam.com/search?q=&app_id=89f75d08&app_key=a50a2a8174970ec300397dea3db7f843&mealType=Dinner';
       let apiRequest = `https://api.edamam.com/api/recipes/v2?type=public&q=&app_id=89f75d08&app_key=a50a2a8174970ec300397dea3db7f843&mealType=Dinner`;
-      console.log('apiRequest: ', apiRequest);
       //Exclude the recipes that we already have.
       if (cuisinePref && cuisinePref !== 'No Preference') {
         apiRequest += `&cuisineType=${cuisinePref}`;

--- a/client/components/RecRecipes.js
+++ b/client/components/RecRecipes.js
@@ -25,7 +25,7 @@ const RecRecipes = () => {
 
   //First, get the recommended recipes and the user's pantry ingredients.
   useEffect(() => {
-    dispatch(showRecRecipes());
+    dispatch(showRecRecipes(cuisinePref));
     dispatch(getOurFoods(id)); //Get the ingredients associated with the user to sort results.
   }, []);
 
@@ -51,10 +51,6 @@ const RecRecipes = () => {
 
     //Only execute the api call after the 2nd render. Otherwise, the recipes needed will be inaccurate.
     if (didMount.current) {
-      console.log(
-        'Matching cuisine pref: ',
-        recRecipes.filter((recRecipe) => recRecipe.cuisineType === cuisinePref)
-      );
       //When the number of rec recipes falls below five, get ten from the api.
       if (recRecipes.length < 5) {
         getMoreRecs();
@@ -65,10 +61,9 @@ const RecRecipes = () => {
         !recRecipes.filter((recRecipe) => recRecipe.cuisineType === cuisinePref)
           .length
       ) {
-        getMoreRecs(recRecipes.length &&
-          !recRecipes.filter((recRecipe) => recRecipe.cuisineType === cuisinePref)
-            .length);
-      } else {
+        getMoreRecs();
+      }
+    } else {
       didMount.current = true;
     }
   }, [recipes]);

--- a/client/components/RecRecipes.js
+++ b/client/components/RecRecipes.js
@@ -55,6 +55,12 @@ const RecRecipes = () => {
       if (recRecipes.length < 5) {
         getMoreRecs();
       }
+    } else if (
+      recRecipes.length &&
+      !recRecipes.filter((recRecipe) => recRecipe.cuisineType === cuisinePref)
+        .length
+    ) {
+      getMoreRecs();
     } else {
       didMount.current = true;
     }

--- a/client/components/RecRecipes.js
+++ b/client/components/RecRecipes.js
@@ -34,7 +34,6 @@ const RecRecipes = () => {
   useEffect(() => {
     async function getMoreRecs() {
       //The base api url with which we request new recommendations.
-
       let apiParams = '';
       //Exclude the recipes that we already have.
       if (cuisinePref && cuisinePref !== 'No Preference') {
@@ -46,15 +45,16 @@ const RecRecipes = () => {
       if (health) {
         apiParams += `&health=${health}`;
       }
-      recipes.forEach((recipe) => {
-        const recipeWords = recipe.name.split(' ').join('%20');
-        apiParams += `&excluded=${recipeWords}`;
-      });
-      //Exclude the recipes already in our recommendations.
-      recRecipes.forEach((recRecipe) => {
-        const recipeWords = recRecipe.name.split(' ').join('%20');
-        apiParams += `&excluded=${recipeWords}`;
-      });
+      apiParams += '&random=true';
+      // recipes.forEach((recipe) => {
+      //   const recipeWords = recipe.name.split(' ').join('%20');
+      //   apiParams += `&excluded=${recipeWords}`;
+      // });
+      // //Exclude the recipes already in our recommendations.
+      // recRecipes.forEach((recRecipe) => {
+      //   const recipeWords = recRecipe.name.split(' ').join('%20');
+      //   apiParams += `&excluded=${recipeWords}`;
+      // });
       dispatch(getNewRecRecipes(apiParams));
     }
 

--- a/client/components/RecRecipes.js
+++ b/client/components/RecRecipes.js
@@ -58,14 +58,17 @@ const RecRecipes = () => {
       //When the number of rec recipes falls below five, get ten from the api.
       if (recRecipes.length < 5) {
         getMoreRecs();
+
+        //If there are recipes present, but none match our cuisine preference (due to account update), search again.
       } else if (
         recRecipes.length &&
         !recRecipes.filter((recRecipe) => recRecipe.cuisineType === cuisinePref)
           .length
       ) {
-        getMoreRecs();
-      }
-    } else {
+        getMoreRecs(recRecipes.length &&
+          !recRecipes.filter((recRecipe) => recRecipe.cuisineType === cuisinePref)
+            .length);
+      } else {
       didMount.current = true;
     }
   }, [recipes]);

--- a/client/components/RecRecipes.js
+++ b/client/components/RecRecipes.js
@@ -36,8 +36,8 @@ const RecRecipes = () => {
       //The base api url with which we request new recommendations.
       // let apiRequest =
       //   'https://api.edamam.com/search?q=&app_id=89f75d08&app_key=a50a2a8174970ec300397dea3db7f843&mealType=Dinner';
-      let apiRequest =
-        'https://api.edamam.com/api/recipes/v2?type=public&q=&app_id=89f75d08&app_key=a50a2a8174970ec300397dea3db7f843&mealType=Dinner';
+      let apiRequest = `https://api.edamam.com/api/recipes/v2?type=public&q=&app_id=89f75d08&app_key=a50a2a8174970ec300397dea3db7f843&mealType=Dinner`;
+      console.log('apiRequest: ', apiRequest);
       //Exclude the recipes that we already have.
       if (cuisinePref && cuisinePref !== 'No Preference') {
         apiRequest += `&cuisineType=${cuisinePref}`;

--- a/client/components/RecRecipes.js
+++ b/client/components/RecRecipes.js
@@ -51,22 +51,24 @@ const RecRecipes = () => {
 
     //Only execute the api call after the 2nd render. Otherwise, the recipes needed will be inaccurate.
     if (didMount.current) {
+      console.log(
+        'Matching cuisine pref: ',
+        recRecipes.filter((recRecipe) => recRecipe.cuisineType === cuisinePref)
+      );
       //When the number of rec recipes falls below five, get ten from the api.
       if (recRecipes.length < 5) {
         getMoreRecs();
+      } else if (
+        recRecipes.length &&
+        !recRecipes.filter((recRecipe) => recRecipe.cuisineType === cuisinePref)
+          .length
+      ) {
+        getMoreRecs();
       }
-    } else if (
-      recRecipes.length &&
-      !recRecipes.filter((recRecipe) => recRecipe.cuisineType === cuisinePref)
-        .length
-    ) {
-      getMoreRecs();
     } else {
       didMount.current = true;
     }
   }, [recipes]);
-
-  console.log('recRecipes: ', recRecipes);
 
   const expandView = (id) => {
     if (id !== currentView) {
@@ -104,6 +106,20 @@ const RecRecipes = () => {
     return recipes;
   }
 
+  function sortByCuisinePref(recipes) {
+    let matches = [];
+    let nonMatches = [];
+    recipes.forEach((recipe) => {
+      if (recipe.cuisineType === cuisinePref) {
+        matches.push(recipe);
+      } else {
+        nonMatches.push(recipe);
+      }
+    });
+    const sortedResults = matches.concat(nonMatches);
+    return sortedResults;
+  }
+
   function addToMyRecipes(recipeId) {
     dispatch(addRecToMyRecipes(recipeId, id));
     dispatch(removeRecRecipe(recipeId));
@@ -111,6 +127,8 @@ const RecRecipes = () => {
 
   //Sort the rec recipes by those that need the least new ingredients.
   recRecipes = sortByAvailablility(recRecipes);
+  //Sort the rec recipes such that the user's cuisineType preference appears first.
+  recRecipes = sortByCuisinePref(recRecipes);
 
   const handleSelect = (selectedIndex, e) => {
     setIndex(selectedIndex);

--- a/client/components/RecRecipes.js
+++ b/client/components/RecRecipes.js
@@ -46,15 +46,6 @@ const RecRecipes = () => {
         apiParams += `&health=${health}`;
       }
       apiParams += '&random=true';
-      // recipes.forEach((recipe) => {
-      //   const recipeWords = recipe.name.split(' ').join('%20');
-      //   apiParams += `&excluded=${recipeWords}`;
-      // });
-      // //Exclude the recipes already in our recommendations.
-      // recRecipes.forEach((recRecipe) => {
-      //   const recipeWords = recRecipe.name.split(' ').join('%20');
-      //   apiParams += `&excluded=${recipeWords}`;
-      // });
       dispatch(getNewRecRecipes(apiParams));
     }
 

--- a/client/components/RecRecipes.js
+++ b/client/components/RecRecipes.js
@@ -32,7 +32,7 @@ const RecRecipes = () => {
   const didMount = useRef(false);
   //Get all the recommended recipes not associated with the current user.
   useEffect(() => {
-    async function getMoreRecs() {
+    function getMoreRecs() {
       //The base api url with which we request new recommendations.
       let apiParams = '';
       //Exclude the recipes that we already have.

--- a/client/store/recRecipes.js
+++ b/client/store/recRecipes.js
@@ -30,10 +30,12 @@ export const removeRecRecipe = (recRecipeId) => {
 // THUNKS
 
 //NOTE: This just gets all the recipes not assigned to the user. When we link up the api, we will need to pass user preferences data to retrieve the right results.
-export const showRecRecipes = () => {
+export const showRecRecipes = (cuisinePref) => {
   return async (dispatch) => {
     try {
-      const { data } = await axios.get('api/recipes/recs');
+      const { data } = await axios.get(
+        `api/recipes/recs?cuisinePref=${cuisinePref}`
+      );
       dispatch(_showRecRecipes(data));
     } catch (error) {
       console.error('Failed to retrieve the recipe recommendations', error);
@@ -89,10 +91,14 @@ export const getNewRecRecipes = (apiParams) => {
 const recRecipesReducer = (state = [], action) => {
   switch (action.type) {
     case SHOW_REC_RECIPES: {
-      return action.recRecipes;
+      let newState = action.recRecipes;
+      if (newState.length > 40) {
+        newState = newState.slice(0, 40);
+      }
+      return newState;
     }
     case ADD_NEW_REC_RECIPE: {
-      return [...state, action.recRecipe];
+      return [action.recRecipe, ...state];
     }
     case REMOVE_REC_RECIPE: {
       return state.filter((recipe) => recipe.id !== action.recRecipeId);

--- a/server/api/recipes.js
+++ b/server/api/recipes.js
@@ -26,17 +26,32 @@ router.get('/', async (req, res, next) => {
   }
 });
 
-// GET /api/recipes/recs
+// GET /api/recipes/recs?cuisinePref=STRING
 router.get('/recs', async (req, res, next) => {
   try {
     // At this stage, we're just getting all the recipes not assigned to any user. With the api, this route will be entirely replaced.
-    const recRecipes = await Recipe.findAll({
+    let recRecipes = await Recipe.findAll({
       where: { userId: { [Op.is]: null } },
       include: Ingredient,
     });
     if (!recRecipes) {
       next({ status: 404, message: 'No recommended recipes found.' });
     }
+
+    if (req.query.cuisinePref) {
+      const { cuisinePref } = req.query;
+      let matches = [];
+      let nonMatches = [];
+      recRecipes.forEach((recipe) => {
+        if (recipe.cuisineType === cuisinePref) {
+          matches.push(recipe);
+        } else {
+          nonMatches.push(recipe);
+        }
+      });
+      recRecipes = matches.concat(nonMatches);
+    }
+
     res.send(recRecipes);
   } catch (error) {
     next(error);

--- a/server/api/recipes.js
+++ b/server/api/recipes.js
@@ -180,6 +180,7 @@ router.post('/recs/new', async (req, res, next) => {
     let apiRequest = `https://api.edamam.com/api/recipes/v2?type=public&q=&app_id=${process.env.REACT_APP_RECIPE_APP_ID}&app_key=${process.env.REACT_APP_RECIPE_KEY}&mealType=Dinner`;
     const { apiParams } = req.body;
     apiRequest += apiParams;
+    console.log('apiRequest: ', apiRequest);
     const apiResponse = await axios.get(apiRequest);
     const hits = apiResponse.data.hits;
     if (hits) {

--- a/server/api/recipes.js
+++ b/server/api/recipes.js
@@ -180,7 +180,6 @@ router.post('/recs/new', async (req, res, next) => {
     let apiRequest = `https://api.edamam.com/api/recipes/v2?type=public&q=&app_id=${process.env.REACT_APP_RECIPE_APP_ID}&app_key=${process.env.REACT_APP_RECIPE_KEY}&mealType=Dinner`;
     const { apiParams } = req.body;
     apiRequest += apiParams;
-    console.log('apiRequest: ', apiRequest);
     const apiResponse = await axios.get(apiRequest);
     const hits = apiResponse.data.hits;
     if (hits) {

--- a/server/api/recipes.js
+++ b/server/api/recipes.js
@@ -92,24 +92,19 @@ router.post('/', async (req, res, next) => {
 
     // Associate recipe ingredients & qtys with recipe
     ingredients.map(async (ingredient) => {
-      const ingredientToAdd = await Ingredient.findOne({
+      let ingredientToAdd = await Ingredient.findOne({
         where: {
           name: ingredient.name,
         },
       });
 
       if (!ingredientToAdd) {
-        next({
-          status: 404,
-          message: `Ingredient ${ingredient.name} not found.`,
-        });
+        ingredientToAdd = await Ingredient.create(ingredient);
       }
 
-      if (!newRecipe.hasIngredient(ingredientToAdd)) {
-        await newRecipe.addIngredient(ingredientToAdd, {
-          through: { recipeQty: ingredient.recipeQty },
-        });
-      }
+      await newRecipe.addIngredient(ingredientToAdd, {
+        through: { recipeQty: ingredient.recipeQty },
+      });
     });
 
     res.send(newRecipe);
@@ -158,12 +153,9 @@ router.post('/recs', async (req, res, next) => {
           ingredientToAdd = await Ingredient.create(ingredient);
         }
 
-        /* Recipes may have duplicate ingredients. If one is already found for the recipe, do not add.*/
-        if (!newRecipe.hasIngredient(ingredientToAdd)) {
-          await newRecipe.addIngredient(ingredientToAdd, {
-            through: { recipeQty: ingredient.quantity },
-          });
-        }
+        await newRecipe.addIngredient(ingredientToAdd, {
+          through: { recipeQty: ingredient.quantity },
+        });
       })
     );
 
@@ -277,17 +269,14 @@ router.put('/:id', async (req, res, next) => {
     // For each recipe, update associated recipe ingredient & its qty
     ingredients.map(async (ingredient) => {
       // Find ingredient to update
-      const ingredientToAdd = await Ingredient.findOne({
+      let ingredientToAdd = await Ingredient.findOne({
         where: {
           name: ingredient.name,
         },
       });
 
       if (!ingredientToAdd) {
-        next({
-          status: 404,
-          message: `Ingredient ${ingredient.name} not found.`,
-        });
+        ingredientToAdd = await Ingredient.create(ingredient);
       }
 
       // Add/updated qty

--- a/server/db/models/Ingredient.js
+++ b/server/db/models/Ingredient.js
@@ -33,7 +33,7 @@ const Ingredient = db.define('ingredient', {
   },
 
   caloriesPerUnit: {
-    type: Sequelize.INTEGER,
+    type: Sequelize.DECIMAL,
     defaultValue: 0,
   },
 

--- a/server/db/models/Ingredient.js
+++ b/server/db/models/Ingredient.js
@@ -67,7 +67,9 @@ Ingredient.beforeCreate(async (food) => {
     food.fatsPerUnit === 0
   ) {
     const res = await axios.get(
-      `https://api.edamam.com/api/food-database/v2/parser?app_id=${process.env.REACT_APP_FOOD_APP_ID}&app_key=${process.env.REACT_APP_FOOD_KEY}&ingr=${food.name}&nutrition-type=cooking`
+      encodeURI(
+        `https://api.edamam.com/api/food-database/v2/parser?app_id=${process.env.REACT_APP_FOOD_APP_ID}&app_key=${process.env.REACT_APP_FOOD_KEY}&ingr=${food.name}&nutrition-type=cooking`
+      )
     );
     if (res.data.parsed.length > 0) {
       const { ENERC_KCAL, PROCNT, FAT, CHOCDF } =

--- a/server/index.js
+++ b/server/index.js
@@ -1,21 +1,21 @@
-const { db } = require('./db')
-const PORT = process.env.PORT || 8080
-const app = require('./app')
+require('dotenv').config();
+const { db } = require('./db');
+const PORT = process.env.PORT || 8080;
+const app = require('./app');
 const seed = require('../script/seed');
 
 const init = async () => {
   try {
-    if(process.env.SEED === 'true'){
+    if (process.env.SEED === 'true') {
       await seed();
-    }
-    else {
-      await db.sync()
+    } else {
+      await db.sync();
     }
     // start listening (and create a 'server' object representing our server)
-    app.listen(PORT, () => console.log(`Mixing it up on port ${PORT}`))
+    app.listen(PORT, () => console.log(`Mixing it up on port ${PORT}`));
   } catch (ex) {
-    console.log(ex)
+    console.log(ex);
   }
-}
+};
 
-init()
+init();


### PR DESCRIPTION
Recommended recipes are sorted primarily according to your cuisine preference. If none matches your cuisine preference, an API request is made for more with your given preference. 
Here's the lifecycle:

1. A user signs up and initially retrieves no more than 40 recommendations (unassigned recipes) from our DB.
2. The user changes their cuisine preference to a given category.
3. When the user returns to the recipe page, the component filters the results to find at least one matching the cuisine preference.
4. If there is none, the API request is made again, which passes the user's cuisine preference. New recipes are created and set on the store.
5. The component sorts the rec. recipes such that the cuisine preference(s) appear first.

NOTE: With many users, there could be at least 20 rec. recipes on the DB per cuisine category. So, if someone views Recipes with no cuisine preference, they could get over 360 results (20 recipes per 18 categories). For that reason, I've limited the number of results to 40. However, when a user adds recommendations and no more match the preferences, it will trigger the API, adding possibly setting more than 40 on store. This is problematic for scaling up, since the DB could explode with new recipes when there are possible matches already present (excluded earlier due to the 40 limit). 

One solution is to check again for more recs from the DB before turning to the API, but I'm not sure how to implement that exactly. Since this is more of an optimization problem, I'll leave it be for now.