### PR TITLE
Fixes/seedenv

### DIFF
--- a/script/seed.js
+++ b/script/seed.js
@@ -1,4 +1,5 @@
 'use strict';
+require('dotenv').config();
 
 const {
   db,

--- a/server/db/models/Ingredient.js
+++ b/server/db/models/Ingredient.js
@@ -68,7 +68,7 @@ Ingredient.beforeCreate(async (food) => {
   ) {
     const res = await axios.get(
       encodeURI(
-        `https://api.edamam.com/api/food-database/v2/parser?app_id=c0c8bb82&app_key=0ebd61fc31cc1482f29f566f8069878f&ingr=${food.name}&nutrition-type=cooking`
+        `https://api.edamam.com/api/food-database/v2/parser?app_id=${process.env.REACT_APP_FOOD_APP_ID}&app_key=${process.env.REACT_APP_FOOD_KEY}&ingr=${food.name}&nutrition-type=cooking`
       )
     );
     if (res.data.parsed.length > 0) {


### PR DESCRIPTION
Ingredient model: Re-added process.env keys to food API call. We just needed to require 'dotenv' in the Seed file, so we can seed now.